### PR TITLE
fix: use full monster feed url

### DIFF
--- a/netlify/functions/fetch_jobs.js
+++ b/netlify/functions/fetch_jobs.js
@@ -9,7 +9,7 @@ const RSS_FEEDS = [
   'https://careers.insidehighered.com/jobsrss/?keywords=asia+education',
   'https://www.timeshighereducation.com/unijobs/rss/?keywords=asia+education',
   'https://www.schrole.com/rss/jobs',
-  'https://rss.jobsearch.monster.com/rssquery.ashx?q=international+education&where=Asia&rad=20&rad_units=miles&cy=US&pp=25&sort=rv.di.dt',
+  'https://rss.jobsearch.monster.com/rssquery.ashx?q=international+education&where=Asia&rad=20&rad_units=miles&cy=US&pp=25&sort=rv.di.dt'
 ];
 
 // Helper to fetch and parse all feeds safely


### PR DESCRIPTION
## Summary
- ensure Monster RSS feed URL is a single continuous string in RSS_FEEDS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68afc0cc47dc83268621cf02c6c77de2